### PR TITLE
Added CSV printing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We provide a number of scripts to automate things. Each is located in the `scrip
 * `scripts/build_rmis.sh` compiles and builds the RMIs for each dataset
   * `scripts/download_rmis.sh` will download pre-built RMIs instead, which may be faster. You'll need to run `build_rmis.sh` if you want to measure build times on your platform.
 * `scripts/prepare.sh` constructs query workloads and compiles the benchmark
-* `scripts/execute.sh` executes the benchmark on each workload, storing the results in `results`
+* `scripts/execute.sh` executes the benchmark on each workload, storing the results in `results`. You can use the `-c` flag to output a .csv file of results rather than a .txt.
 
 Build times can be long, as we make aggressive use of templates to ensure we do not accidentally measure vtable lookup time. For development, this can be annoying: you can set `USE_FAST_MODE` in `config.h` to disable some features and get a faster build time.
 

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -25,7 +25,7 @@
 using namespace std;
 
 #define check_only(tag, code) if ((!only_mode) || only == tag) { code; }
-#define add_search_type(name, func, type, search_class) { if (search_type == (name)) { auto search = search_class<type>(); sosd::Benchmark<type, search_class> benchmark(filename, lookups, dataset, num_repeats, perf, build, fence, cold_cache, track_errors, csv, num_threads, search); func(benchmark, pareto, only_mode, only, filename); found_search_type = true; break; } }
+#define add_search_type(name, func, type, search_class) { if (search_type == (name)) { auto search = search_class<type>(); sosd::Benchmark<type, search_class> benchmark(filename, lookups, num_repeats, perf, build, fence, cold_cache, track_errors, csv, num_threads, search); func(benchmark, pareto, only_mode, only, filename); found_search_type = true; break; } }
 
 template<class Benchmark>
 void execute_32_bit(Benchmark benchmark, bool pareto,
@@ -85,7 +85,6 @@ int main(int argc, char* argv[]) {
   options.add_options()
       ("data", "Data file with keys", cxxopts::value<std::string>())
       ("lookups", "Lookup key (query) file", cxxopts::value<std::string>())
-      ("dataset", "Dataset name", cxxopts::value<std::string>())
       ("help", "Displays help")
       ("r,repeats",
        "Number of repeats",
@@ -109,7 +108,7 @@ int main(int argc, char* argv[]) {
        "extra positional arguments",
        cxxopts::value<std::vector<std::string>>());
 
-  options.parse_positional({"data", "lookups", "dataset", "positional"});
+  options.parse_positional({"data", "lookups", "positional"});
 
   const auto result = options.parse(argc, argv);
 
@@ -133,7 +132,6 @@ int main(int argc, char* argv[]) {
   const bool pareto = result.count("pareto");
   const std::string filename = result["data"].as<std::string>();
   const std::string lookups = result["lookups"].as<std::string>();
-  const std::string dataset = result["dataset"].as<std::string>();
   const std::string search_type = result["search"].as<std::string>();
   const bool only_mode = result.count("only") || std::getenv("SOSD_ONLY");
   std::string only;

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -25,7 +25,7 @@
 using namespace std;
 
 #define check_only(tag, code) if ((!only_mode) || only == tag) { code; }
-#define add_search_type(name, func, type, search_class) { if (search_type == (name)) { auto search = search_class<type>(); sosd::Benchmark<type, search_class> benchmark(filename, lookups, num_repeats, perf, build, fence, cold_cache, track_errors, num_threads, search); func(benchmark, pareto, only_mode, only, filename); found_search_type = true; break; } }
+#define add_search_type(name, func, type, search_class) { if (search_type == (name)) { auto search = search_class<type>(); sosd::Benchmark<type, search_class> benchmark(filename, lookups, dataset, num_repeats, perf, build, fence, cold_cache, track_errors, csv, num_threads, search); func(benchmark, pareto, only_mode, only, filename); found_search_type = true; break; } }
 
 template<class Benchmark>
 void execute_32_bit(Benchmark benchmark, bool pareto,
@@ -85,6 +85,7 @@ int main(int argc, char* argv[]) {
   options.add_options()
       ("data", "Data file with keys", cxxopts::value<std::string>())
       ("lookups", "Lookup key (query) file", cxxopts::value<std::string>())
+      ("dataset", "Dataset name", cxxopts::value<std::string>())
       ("help", "Displays help")
       ("r,repeats",
        "Number of repeats",
@@ -100,6 +101,7 @@ int main(int argc, char* argv[]) {
       ("pareto", "Run with multiple different sizes for each competitor")
       ("fence", "Execute a memory barrier between each lookup")
       ("errors", "Tracks index errors, and report those instead of lookup times")
+      ("csv", "Output a CSV of results in addition to a text file")
       ("search",
        "Specify a search type, one of: binary, branchless_binary, linear, interpolation",
        cxxopts::value<std::string>()->default_value("binary"))
@@ -107,7 +109,7 @@ int main(int argc, char* argv[]) {
        "extra positional arguments",
        cxxopts::value<std::vector<std::string>>());
 
-  options.parse_positional({"data", "lookups", "positional"});
+  options.parse_positional({"data", "lookups", "dataset", "positional"});
 
   const auto result = options.parse(argc, argv);
 
@@ -127,9 +129,11 @@ int main(int argc, char* argv[]) {
   const bool fence = result.count("fence");
   const bool track_errors = result.count("errors");
   const bool cold_cache = result.count("cold-cache");
+  const bool csv = result.count("csv");
   const bool pareto = result.count("pareto");
   const std::string filename = result["data"].as<std::string>();
   const std::string lookups = result["lookups"].as<std::string>();
+  const std::string dataset = result["dataset"].as<std::string>();
   const std::string search_type = result["search"].as<std::string>();
   const bool only_mode = result.count("only") || std::getenv("SOSD_ONLY");
   std::string only;

--- a/benchmark.h
+++ b/benchmark.h
@@ -50,7 +50,7 @@ class Benchmark {
         num_repeats_(num_repeats),
         first_run_(true), perf(perf), build(build), fence(fence),
         cold_cache(cold_cache), track_errors(track_errors),
-        csv(csv), num_threads_(num_threads),
+        csv_(csv), num_threads_(num_threads),
         searcher(searcher) {
     
     if ((int)cold_cache + (int)perf + (int)fence > 1) {
@@ -326,14 +326,14 @@ private:
                 << "," << searcher.name()
                 << std::endl;
     }
-    if (csv) {
+    if (csv_) {
       PrintResultCSV(index);
     }
   }
 
   template<class Index>
   void PrintResultCSV(const Index& index) {
-    std::string filename = "./results/" + dataset_name_ + "_results_table.csv";
+    const std::string filename = "./results/" + dataset_name_ + "_results_table.csv";
 
     std::ofstream fout(filename, std::ofstream::out | std::ofstream::app);
 
@@ -418,10 +418,10 @@ private:
   bool perf;
   bool build;
   bool fence;
-  bool measure_each;
+  bool measure_each_;
   bool cold_cache;
   bool track_errors;
-  bool csv;
+  bool csv_;
   // Number of lookup threads.
   const size_t num_threads_;
 

--- a/benchmark.h
+++ b/benchmark.h
@@ -395,6 +395,7 @@ private:
     
     fout.close();
     return;
+  }
 
   uint64_t random_sum = 0;
   uint64_t individual_ns_sum = 0;

--- a/benchmark.h
+++ b/benchmark.h
@@ -389,12 +389,12 @@ private:
            << "," << index.size()
            << "," << build_ns_
            << "," << searcher.name()
+	   << "," << dataset_name_
            << std::endl;
     }
     
     fout.close();
     return;
-  }
 
   uint64_t random_sum = 0;
   uint64_t individual_ns_sum = 0;

--- a/scripts/execute.sh
+++ b/scripts/execute.sh
@@ -21,7 +21,7 @@ function do_benchmark() {
         echo "Already have results for $1"
     else
         echo "Executing workload $1"
-        $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M $1 --pareto | tee ./results/$1_results.txt
+        $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M --pareto | tee ./results/$1_results.txt
     fi
 }
 
@@ -34,7 +34,7 @@ function do_benchmark_csv() {
 	rm $RESULTS
     fi
     echo "Executing workload $1 and printing to CSV"
-    $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M $1 --pareto --csv
+    $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M --pareto --csv
 }
 
 mkdir -p ./results

--- a/scripts/execute.sh
+++ b/scripts/execute.sh
@@ -2,6 +2,12 @@
 
 echo "Executing benchmark and saving results..."
 
+while getopts "c" arg; do
+    case $arg in
+        c) do_csv=true;;
+    esac
+done
+
 BENCHMARK=build/benchmark
 if [ ! -f $BENCHMARK ]; then
     echo "benchmark binary does not exist"
@@ -15,12 +21,28 @@ function do_benchmark() {
         echo "Already have results for $1"
     else
         echo "Executing workload $1"
-        $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M --pareto | tee ./results/$1_results.txt
+        $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M $1 --pareto | tee ./results/$1_results.txt
     fi
+}
+
+function do_benchmark_csv() {
+
+    RESULTS=./results/$1_results_table.csv
+    if [ -f $RESULTS ]; then
+	# Previously existing file could be from incomplete run
+        echo "Removing results CSV for $1"
+	rm $RESULTS
+    fi
+    echo "Executing workload $1 and printing to CSV"
+    $BENCHMARK -r 1 ./data/$1 ./data/$1_equality_lookups_10M $1 --pareto --csv
 }
 
 mkdir -p ./results
 
 for dataset in $(cat scripts/datasets_under_test.txt); do
-    do_benchmark "$dataset"
+    if [ "$do_csv" = true ]; then
+        do_benchmark_csv "$dataset"
+    else
+        do_benchmark "$dataset"
+    fi
 done


### PR DESCRIPTION
Minor changes adding the ability to output a CSV file of results instead of a .txt file. Running `bash scripts/execute.sh` with the `-c` flag now prints a CSV into the `./results` directory.