### PR TITLE
Implement faster FST lookup codepath

### DIFF
--- a/benchmarks/benchmark_fst.cc
+++ b/benchmarks/benchmark_fst.cc
@@ -7,6 +7,9 @@
 template <template <typename> typename Searcher>
 void benchmark_32_fst(sosd::Benchmark<uint32_t, Searcher>& benchmark,
                       bool pareto) {
+  benchmark.template Run<FST<uint32_t, 1, true>>();
+  benchmark.template Run<FST<uint32_t, 1, false>>();
+
   benchmark.template Run<FST<uint32_t, 128>>();
   if (pareto) {
     benchmark.template Run<FST<uint32_t, 256>>();
@@ -21,6 +24,9 @@ void benchmark_32_fst(sosd::Benchmark<uint32_t, Searcher>& benchmark,
 template <template <typename> typename Searcher>
 void benchmark_64_fst(sosd::Benchmark<uint64_t, Searcher>& benchmark,
                       bool pareto) {
+  benchmark.template Run<FST<uint64_t, 1, true>>();
+  benchmark.template Run<FST<uint64_t, 1, false>>();
+
   benchmark.template Run<FST<uint64_t, 128>>();
   if (pareto) {
     benchmark.template Run<FST<uint64_t, 256>>();

--- a/benchmarks/benchmark_fst.cc
+++ b/benchmarks/benchmark_fst.cc
@@ -7,9 +7,7 @@
 template <template <typename> typename Searcher>
 void benchmark_32_fst(sosd::Benchmark<uint32_t, Searcher>& benchmark,
                       bool pareto) {
-  benchmark.template Run<FST<uint32_t, 1, true>>();
-  benchmark.template Run<FST<uint32_t, 1, false>>();
-
+  benchmark.template Run<FST<uint32_t, 1>>();
   benchmark.template Run<FST<uint32_t, 128>>();
   if (pareto) {
     benchmark.template Run<FST<uint32_t, 256>>();
@@ -24,9 +22,7 @@ void benchmark_32_fst(sosd::Benchmark<uint32_t, Searcher>& benchmark,
 template <template <typename> typename Searcher>
 void benchmark_64_fst(sosd::Benchmark<uint64_t, Searcher>& benchmark,
                       bool pareto) {
-  benchmark.template Run<FST<uint64_t, 1, true>>();
-  benchmark.template Run<FST<uint64_t, 1, false>>();
-
+  benchmark.template Run<FST<uint64_t, 1>>();
   benchmark.template Run<FST<uint64_t, 128>>();
   if (pareto) {
     benchmark.template Run<FST<uint64_t, 256>>();

--- a/competitors/fst_wrapper.h
+++ b/competitors/fst_wrapper.h
@@ -53,20 +53,14 @@ class FST : public Competitor {
       key = std::string(reinterpret_cast<const char*>(&endian_swapped_word), 4);
     }
 
-    uint64_t guess;
+    uint64_t guess = 0;
     if (lookup_key >= max_key_) {
       // looking up a value greater than the largest value causes a segfault...
       return (SearchBound){max_val_, data_size_};
       std::cout << max_val_ << "!!!" << std::endl;
     } else {
-      auto iter = fst_->moveToKeyGreaterThan(key, true);
-
-      // sometimes we get back a bad iterator even though
-      // we shouldn't...
-      if (!iter.isValid()) return (SearchBound){0, data_size_};
-
-      // multiply by size_scale here because getValue() returns an index
-      guess = iter.getValue() * size_scale;
+      if (!fst_->lookupKey(key, guess)) return {0, data_size_};
+      guess *= size_scale;
     }
 
     // expanding by error in both directions is faster than

--- a/competitors/fst_wrapper.h
+++ b/competitors/fst_wrapper.h
@@ -5,7 +5,7 @@
 #include "./FST/include/fst.hpp"
 #include "base.h"
 
-template <class KeyType, int size_scale, bool turbomode = false>
+template <class KeyType, int size_scale>
 class FST : public Competitor {
  public:
   // assume that keys are unique and sorted in ascending order
@@ -60,10 +60,10 @@ class FST : public Competitor {
       std::cout << max_val_ << "!!!" << std::endl;
     }
 
-    // faster codepath on size_scale == 1
-    if constexpr (turbomode /*&& size_scale == 1*/) {
+    // faster codepath on size_scale == 1 (static if evaluated at compile time)
+    if constexpr (size_scale == 1) {
       fst_->lookupKey(key, guess);
-      guess *= size_scale;
+      return {guess, guess};
     } else {
       auto iter = fst_->moveToKeyGreaterThan(key, true);
 
@@ -90,7 +90,7 @@ class FST : public Competitor {
     return (SearchBound){start, stop};
   }
 
-  std::string name() const { return std::string(turbomode ? "F" : "") + "FST"; }
+  std::string name() const { return "FST"; }
 
   std::size_t size() const {
     // return used memory in bytes


### PR DESCRIPTION
Hi everyone!

This PR contains a change to the FST lookup codepath that seems to shave off a significant chunk of time in most cases. Please find an excerpt of results taken on a 2x Xeon Gold 6230 CPU, 256GB RAM Linux 5.14.8 (arch) server bellow. Negative 'variant' number (-128, -256, et cetera) indicates the new, faster codepath. Positive numbers indicate the old, unchanged code:

![Screenshot 2022-01-19 at 12 58 38](https://user-images.githubusercontent.com/11378012/150125355-333dd307-fc86-45f5-8455-19440793e8b2.png)