### PR TITLE
Add analysis-RMI to SOSD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "competitors/ts"]
 	path = competitors/ts
 	url = https://github.com/stoianmihail/TrieSpline.git
+[submodule "competitors/analysis-rmi"]
+	path = competitors/analysis-rmi
+	url = https://github.com/BigDataAnalyticsGroup/analysis-rmi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,4 +27,4 @@
 	url = https://github.com/stoianmihail/TrieSpline.git
 [submodule "competitors/analysis-rmi"]
 	path = competitors/analysis-rmi
-	url = https://github.com/BigDataAnalyticsGroup/analysis-rmi.git
+	url = https://github.com/alhuan/analysis-rmi.git

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -58,7 +58,7 @@ void execute_32_bit(Benchmark benchmark, bool pareto, bool only_mode,
   check_only("IBTree", benchmark_32_ibtree(benchmark, pareto));
   check_only("FAST", benchmark_32_fast(benchmark, pareto));
   check_only("ALEX", benchmark_32_alex(benchmark, pareto));
-  check_only("RMI_ALT", benchmark_32_rmi_alt(benchmark, pareto));
+  check_only("RMI_CPP", benchmark_32_rmi_cpp(benchmark, pareto));
 #ifndef __APPLE__
 #ifndef DISABLE_FST
   check_only("FST", benchmark_32_fst(benchmark, pareto));
@@ -88,7 +88,7 @@ void execute_64_bit(Benchmark benchmark, bool pareto, bool only_mode,
   check_only("IBTree", benchmark_64_ibtree(benchmark, pareto));
   check_only("FAST", benchmark_64_fast(benchmark, pareto));
   check_only("ALEX", benchmark_64_alex(benchmark, pareto));
-  check_only("RMI_ALT", benchmark_64_rmi_alt(benchmark, pareto));
+  check_only("RMI_CPP", benchmark_64_rmi_cpp(benchmark, pareto));
 #ifndef __APPLE__
 #ifndef DISABLE_FST
   check_only("FST", benchmark_64_fst(benchmark, pareto));

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -12,6 +12,7 @@
 #include "benchmarks/benchmark_pgm.h"
 #include "benchmarks/benchmark_rbs.h"
 #include "benchmarks/benchmark_rmi.h"
+#include "benchmarks/benchmark_rmi_alt.h"
 #include "benchmarks/benchmark_rs.h"
 #include "benchmarks/benchmark_ts.h"
 #include "benchmarks/benchmark_wormhole.h"
@@ -57,6 +58,7 @@ void execute_32_bit(Benchmark benchmark, bool pareto, bool only_mode,
   check_only("IBTree", benchmark_32_ibtree(benchmark, pareto));
   check_only("FAST", benchmark_32_fast(benchmark, pareto));
   check_only("ALEX", benchmark_32_alex(benchmark, pareto));
+  check_only("RMI_ALT", benchmark_32_rmi_alt(benchmark, pareto));
 #ifndef __APPLE__
 #ifndef DISABLE_FST
   check_only("FST", benchmark_32_fst(benchmark, pareto));
@@ -86,6 +88,7 @@ void execute_64_bit(Benchmark benchmark, bool pareto, bool only_mode,
   check_only("IBTree", benchmark_64_ibtree(benchmark, pareto));
   check_only("FAST", benchmark_64_fast(benchmark, pareto));
   check_only("ALEX", benchmark_64_alex(benchmark, pareto));
+  check_only("RMI_ALT", benchmark_64_rmi_alt(benchmark, pareto));
 #ifndef __APPLE__
 #ifndef DISABLE_FST
   check_only("FST", benchmark_64_fst(benchmark, pareto));

--- a/benchmarks/benchmark_rmi_alt.cc
+++ b/benchmarks/benchmark_rmi_alt.cc
@@ -1,37 +1,40 @@
-#pragma once
-#include <string>
+#include "benchmarks/benchmark_rmi_alt.h"
 
 #include "benchmark.h"
+#include "common.h"
 #include "competitors/rmi_alt.h"
 #include "competitors/analysis-rmi/include/rmi/models.hpp"
 #include "competitors/analysis-rmi/include/rmi/rmi.hpp"
 
 template <template <typename> typename Searcher>
 void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
-                          bool pareto, const std::string& filename) {
+                          bool pareto) {
     benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
     if (pareto) {
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 1>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 2>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 3>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 4>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 5>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 6>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 7>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 8>>();
     }
 }
 
 template <template <typename> typename Searcher>
 void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
-                          bool pareto, const std::string& filename) {
+                          bool pareto) {
   benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
   if (pareto) {
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 1>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 2>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 3>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 4>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 5>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 6>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 7>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 8>>();
   }
 }
+
+INSTANTIATE_TEMPLATES(benchmark_32_rmi_alt, uint32_t);
+INSTANTIATE_TEMPLATES(benchmark_64_rmi_alt, uint64_t);

--- a/benchmarks/benchmark_rmi_alt.cc
+++ b/benchmarks/benchmark_rmi_alt.cc
@@ -1,0 +1,37 @@
+#pragma once
+#include <string>
+
+#include "benchmark.h"
+#include "competitors/rmi_alt.h"
+#include "competitors/analysis-rmi/include/rmi/models.hpp"
+#include "competitors/analysis-rmi/include/rmi/rmi.hpp"
+
+template <template <typename> typename Searcher>
+void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
+                          bool pareto, const std::string& filename) {
+    benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
+    if (pareto) {
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 1>>();
+      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 1>>();
+    }
+}
+
+template <template <typename> typename Searcher>
+void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
+                          bool pareto, const std::string& filename) {
+  benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
+  if (pareto) {
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 1>>();
+    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 1>>();
+  }
+}

--- a/benchmarks/benchmark_rmi_alt.cc
+++ b/benchmarks/benchmark_rmi_alt.cc
@@ -4,69 +4,53 @@
 #include "common.h"
 #include "competitors/analysis-rmi/include/rmi/models.hpp"
 #include "competitors/analysis-rmi/include/rmi/rmi.hpp"
-#include "competitors/rmi_alt.h"
+#include "competitors/rmi_cpp.h"
 
 template <template <typename> typename Searcher>
-void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
+void benchmark_32_rmi_cpp(sosd::Benchmark<uint32_t, Searcher>& benchmark,
                           bool pareto) {
-  benchmark.template Run<
-      RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+  benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                    rmi::RmiLAbs, 128, 1>>();
   if (pareto) {
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 256, 2>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 512, 3>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 1024, 4>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 2048, 5>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 4096, 6>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 8192, 7>>();
-    benchmark.template Run<
-        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 16384, 8>>();
   }
 }
 
 template <template <typename> typename Searcher>
-void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
+void benchmark_64_rmi_cpp(sosd::Benchmark<uint64_t, Searcher>& benchmark,
                           bool pareto) {
-  benchmark.template Run<
-      RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+  benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                    rmi::RmiLAbs, 128, 1>>();
   if (pareto) {
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 256, 2>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 512, 3>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 1024, 4>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 2048, 5>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 4096, 6>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 8192, 7>>();
-    benchmark.template Run<
-        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+    benchmark.template Run<RMICpp<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
                      rmi::RmiLAbs, 16384, 8>>();
   }
 }
 
-INSTANTIATE_TEMPLATES(benchmark_32_rmi_alt, uint32_t);
-INSTANTIATE_TEMPLATES(benchmark_64_rmi_alt, uint64_t);
+INSTANTIATE_TEMPLATES(benchmark_32_rmi_cpp, uint32_t);
+INSTANTIATE_TEMPLATES(benchmark_64_rmi_cpp, uint64_t);

--- a/benchmarks/benchmark_rmi_alt.cc
+++ b/benchmarks/benchmark_rmi_alt.cc
@@ -2,37 +2,69 @@
 
 #include "benchmark.h"
 #include "common.h"
-#include "competitors/rmi_alt.h"
 #include "competitors/analysis-rmi/include/rmi/models.hpp"
 #include "competitors/analysis-rmi/include/rmi/rmi.hpp"
+#include "competitors/rmi_alt.h"
 
 template <template <typename> typename Searcher>
 void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
                           bool pareto) {
-    benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
-    if (pareto) {
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 2>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 3>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 4>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 5>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 6>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 7>>();
-      benchmark.template Run<RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 8>>();
-    }
+  benchmark.template Run<
+      RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                   rmi::RmiLAbs, 128, 1>>();
+  if (pareto) {
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 256, 2>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 512, 3>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 1024, 4>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 2048, 5>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 4096, 6>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 8192, 7>>();
+    benchmark.template Run<
+        RMIAlternate<uint32_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 16384, 8>>();
+  }
 }
 
 template <template <typename> typename Searcher>
 void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
                           bool pareto) {
-  benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 128, 1>>();
+  benchmark.template Run<
+      RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                   rmi::RmiLAbs, 128, 1>>();
   if (pareto) {
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 256, 2>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 512, 3>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 1024, 4>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 2048, 5>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 4096, 6>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 8192, 7>>();
-    benchmark.template Run<RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression, rmi::RmiLAbs, 16384, 8>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 256, 2>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 512, 3>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 1024, 4>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 2048, 5>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 4096, 6>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 8192, 7>>();
+    benchmark.template Run<
+        RMIAlternate<uint64_t, rmi::LinearSpline, rmi::LinearRegression,
+                     rmi::RmiLAbs, 16384, 8>>();
   }
 }
 

--- a/benchmarks/benchmark_rmi_alt.h
+++ b/benchmarks/benchmark_rmi_alt.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <string>
-
 #include "benchmark.h"
 
 template <template <typename> typename Searcher>

--- a/benchmarks/benchmark_rmi_alt.h
+++ b/benchmarks/benchmark_rmi_alt.h
@@ -2,9 +2,9 @@
 #include "benchmark.h"
 
 template <template <typename> typename Searcher>
-void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
+void benchmark_32_rmi_cpp(sosd::Benchmark<uint32_t, Searcher>& benchmark,
                       bool pareto);
 
 template <template <typename> typename Searcher>
-void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
+void benchmark_64_rmi_cpp(sosd::Benchmark<uint64_t, Searcher>& benchmark,
                       bool pareto);

--- a/benchmarks/benchmark_rmi_alt.h
+++ b/benchmarks/benchmark_rmi_alt.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+
+#include "benchmark.h"
+
+template <template <typename> typename Searcher>
+void benchmark_32_rmi_alt(sosd::Benchmark<uint32_t, Searcher>& benchmark,
+                      bool pareto);
+
+template <template <typename> typename Searcher>
+void benchmark_64_rmi_alt(sosd::Benchmark<uint64_t, Searcher>& benchmark,
+                      bool pareto);

--- a/competitors/rmi_alt.h
+++ b/competitors/rmi_alt.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include <utility>
 #include <memory>
+#include <utility>
 
-#include "./analysis-rmi/include/rmi/rmi.hpp"
 #include "./analysis-rmi/include/rmi/models.hpp"
+#include "./analysis-rmi/include/rmi/rmi.hpp"
 #include "base.h"
 
 // Alternate implementation of RMI as described by Maltry and Dittrich
-template <class KeyType, typename Layer1, typename Layer2, template <typename...> typename RMIType, size_t layer2_size, uint32_t variant_num>
+template <class KeyType, typename Layer1, typename Layer2,
+          template <typename...> typename RMIType, size_t layer2_size,
+          uint32_t variant_num>
 class RMIAlternate : public Competitor {
  public:
   uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {
@@ -18,20 +20,16 @@ class RMIAlternate : public Competitor {
       loading_data.push_back(itm.key);
     }
 
-    return util::timing(
-        [&] {
-          auto new_rmi_ptr = std::make_unique<RMIType<KeyType, Layer1, Layer2>>(loading_data, layer2_size);
-          rmi_ = std::move(new_rmi_ptr);
-        });
+    return util::timing([&] {
+      auto new_rmi_ptr = std::make_unique<RMIType<KeyType, Layer1, Layer2>>(
+          loading_data, layer2_size);
+      rmi_ = std::move(new_rmi_ptr);
+    });
   }
 
   std::string name() const { return "RMIAlternate"; }
 
-  std::size_t size() const {
-    return rmi_->size_in_bytes();
-//    RMIType<KeyType, Layer1, Layer2>& ref = const_cast<RMIType<KeyType, Layer1, Layer2>&>(rmi_);
-//    return ref.size_in_bytes();
-  }
+  std::size_t size() const { return rmi_->size_in_bytes(); }
 
   SearchBound EqualityLookup(const KeyType lookup_key) const {
     auto it = rmi_->search(lookup_key);

--- a/competitors/rmi_alt.h
+++ b/competitors/rmi_alt.h
@@ -7,7 +7,7 @@
 #include "base.h"
 
 // Alternate implementation of RMI as described by Maltry and Dittrich
-template <class KeyType, typename Layer1, typename Layer2, typename RMIType, size_t layer2_size, int variant>
+template <class KeyType, typename Layer1, typename Layer2, template <KeyType, Layer1, Layer2> typename RMIType, size_t layer2_size, int variant>
 class RMIAlternate : public Competitor {
  public:
   uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {

--- a/competitors/rmi_alt.h
+++ b/competitors/rmi_alt.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <utility>
+
+#include "./analysis-rmi/include/rmi/rmi.hpp"
+#include "./analysis-rmi/include/rmi/models.hpp"
+#include "base.h"
+
+// Alternate implementation of RMI as described by Maltry and Dittrich
+template <class KeyType, typename Layer1, typename Layer2, rmi::Rmi RMIType, size_t layer2_size, int variant>
+class RMIAlternate : public Competitor {
+ public:
+  uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {
+    std::vector<std::pair<KeyType, uint64_t>> loading_data;
+    loading_data.reserve(data.size());
+    for (auto& itm : data) {
+      uint64_t idx = itm.value;
+      loading_data.push_back(std::make_pair(itm.key, itm.value));
+    }
+
+    data_size_ = data.size();
+    return util::timing(
+        [&] {
+          rmi_ = RMIType<KeyType, Layer1, Layer2>(loading_data, layer2_size);
+        });
+  }
+
+  std::string name() const { return "RMIAlternate"; }
+
+  std::size_t size() const { return rmi_.size_in_bytes(); }
+
+  SearchBound EqualityLookup(const KeyType lookup_key) const {
+    auto it = rmi_.search(lookup_key);
+    return (SearchBound){it.lo, it.hi};
+  }
+
+  int variant() const { return variant; }
+
+ private:
+  uint64_t data_size_ = 0;
+  RMIType<KeyType, Layer1, Layer2> rmi_;
+};

--- a/competitors/rmi_alt.h
+++ b/competitors/rmi_alt.h
@@ -7,7 +7,7 @@
 #include "base.h"
 
 // Alternate implementation of RMI as described by Maltry and Dittrich
-template <class KeyType, typename Layer1, typename Layer2, rmi::Rmi RMIType, size_t layer2_size, int variant>
+template <class KeyType, typename Layer1, typename Layer2, typename RMIType, size_t layer2_size, int variant>
 class RMIAlternate : public Competitor {
  public:
   uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {

--- a/competitors/rmi_alt.h
+++ b/competitors/rmi_alt.h
@@ -1,42 +1,45 @@
 #pragma once
 
 #include <utility>
+#include <memory>
 
 #include "./analysis-rmi/include/rmi/rmi.hpp"
 #include "./analysis-rmi/include/rmi/models.hpp"
 #include "base.h"
 
 // Alternate implementation of RMI as described by Maltry and Dittrich
-template <class KeyType, typename Layer1, typename Layer2, template <KeyType, Layer1, Layer2> typename RMIType, size_t layer2_size, int variant>
+template <class KeyType, typename Layer1, typename Layer2, template <typename...> typename RMIType, size_t layer2_size, uint32_t variant_num>
 class RMIAlternate : public Competitor {
  public:
   uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {
-    std::vector<std::pair<KeyType, uint64_t>> loading_data;
+    std::vector<KeyType> loading_data;
     loading_data.reserve(data.size());
     for (auto& itm : data) {
-      uint64_t idx = itm.value;
-      loading_data.push_back(std::make_pair(itm.key, itm.value));
+      loading_data.push_back(itm.key);
     }
 
-    data_size_ = data.size();
     return util::timing(
         [&] {
-          rmi_ = RMIType<KeyType, Layer1, Layer2>(loading_data, layer2_size);
+          auto new_rmi_ptr = std::make_unique<RMIType<KeyType, Layer1, Layer2>>(loading_data, layer2_size);
+          rmi_ = std::move(new_rmi_ptr);
         });
   }
 
   std::string name() const { return "RMIAlternate"; }
 
-  std::size_t size() const { return rmi_.size_in_bytes(); }
+  std::size_t size() const {
+    return rmi_->size_in_bytes();
+//    RMIType<KeyType, Layer1, Layer2>& ref = const_cast<RMIType<KeyType, Layer1, Layer2>&>(rmi_);
+//    return ref.size_in_bytes();
+  }
 
   SearchBound EqualityLookup(const KeyType lookup_key) const {
-    auto it = rmi_.search(lookup_key);
+    auto it = rmi_->search(lookup_key);
     return (SearchBound){it.lo, it.hi};
   }
 
-  int variant() const { return variant; }
+  int variant() const { return variant_num; }
 
  private:
-  uint64_t data_size_ = 0;
-  RMIType<KeyType, Layer1, Layer2> rmi_;
+  std::unique_ptr<RMIType<KeyType, Layer1, Layer2>> rmi_;
 };

--- a/competitors/rmi_cpp.h
+++ b/competitors/rmi_cpp.h
@@ -7,11 +7,11 @@
 #include "./analysis-rmi/include/rmi/rmi.hpp"
 #include "base.h"
 
-// Alternate implementation of RMI as described by Maltry and Dittrich
+// Alternate implementation of RMI in C++
 template <class KeyType, typename Layer1, typename Layer2,
           template <typename...> typename RMIType, size_t layer2_size,
           uint32_t variant_num>
-class RMIAlternate : public Competitor {
+class RMICpp : public Competitor {
  public:
   uint64_t Build(const std::vector<KeyValue<KeyType>>& data) {
     std::vector<KeyType> loading_data;
@@ -27,7 +27,7 @@ class RMIAlternate : public Competitor {
     });
   }
 
-  std::string name() const { return "RMIAlternate"; }
+  std::string name() const { return "RMICpp"; }
 
   std::size_t size() const { return rmi_->size_in_bytes(); }
 


### PR DESCRIPTION
Adding analysis version of RMI as described in [Dittrich](https://arxiv.org/pdf/2106.16166.pdf ) to SOSD. analysis-rmi submodule is a fork I made of their repository due to filepath conflicts with existing `rmi` directory.