### PR TITLE
Revert accidentally commited hunk in fst_wrapper.h

### DIFF
--- a/competitors/fst_wrapper.h
+++ b/competitors/fst_wrapper.h
@@ -102,7 +102,7 @@ class FST : public Competitor {
     return unique;
   }
 
-  int variant() const { return (turbomode ? -1 : 1) * size_scale; }
+  int variant() const { return size_scale; }
 
  private:
   std::unique_ptr<fst::FST> fst_;


### PR DESCRIPTION
This patch should fix the build error introduced by my previous patches. The line in question belongs to internal testing and should not have been part of the original PR - sorry!

I've verified that this indeed fixes SOSD build before submit both locally and on the linux server I run benchmarks on.